### PR TITLE
fix(gradle): Update to JavaFX 18

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ tasks {
     }
     
     javafx {
-        version = "17"
+        version = "18"
         val mods = mutableListOf("javafx.base", "javafx.controls", "javafx.fxml")
         if(debug)
             mods.addAll(listOf("javafx.swing"))


### PR DESCRIPTION
This fixes another crash on ARM macOS: https://stackoverflow.com/questions/70388342/why-do-i-keep-getting-this-sigbus-error-code-on-my-macos-when-trying-to-run-a-ja