### PR TITLE
Bump JavaFX to 17.0.8 (fixing the GUI crash on macOS)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ tasks {
     }
     
     javafx {
-        version = "17"
+        version = "17.0.8"
         val mods = mutableListOf("javafx.base", "javafx.controls", "javafx.fxml")
         if(debug)
             mods.addAll(listOf("javafx.swing"))


### PR DESCRIPTION
### Fixes #91 

As listed in the backports section of https://bugs.openjdk.org/browse/JDK-8296654, the fix was backported in JavaFX 17.0.7, so updating the version fixes the crash on macOS:

<img width="1212" alt="image" src="https://github.com/software-challenge/gui/assets/30873659/c1510b8f-bd48-499e-ad9f-a1c37b5cba2c">
